### PR TITLE
Feature/credits

### DIFF
--- a/Client/Script/BulkActionCommon.js
+++ b/Client/Script/BulkActionCommon.js
@@ -391,7 +391,7 @@ class BulkActionCommon {
             const bEd = episodeData[b.episodeId];
             if (aEd.seasonIndex != bEd.seasonIndex) { return aEd.seasonIndex - bEd.seasonIndex; }
             if (aEd.index != bEd.index) { return aEd.index - bEd.index; }
-            return a.index - b.index;
+            return a.start - b.start;
         });
     }
 

--- a/Client/Script/BulkAddOverlay.js
+++ b/Client/Script/BulkAddOverlay.js
@@ -315,17 +315,22 @@ class BulkAddRow extends BulkActionRow {
         }
 
         for (const existingMarker of this.#existingMarkers) {
+            // [Existing...{New++]---} or [Existing...{New++}...]
             if (start >= existingMarker.start && start <= existingMarker.end) {
                 isWarn = true;
                 semiWarn = false;
                 this.#startTd.classList.add(warnClass);
+                if (end < existingMarker.end) {
+                    this.#setSingleClass(this.#endTd, warnClass);
+                }
+
                 tooltip += `<br>Overlaps with existing marker [${msToHms(existingMarker.start)}-${msToHms(existingMarker.end)}]`;
+                
                 if (resolveType == BulkMarkerResolveType.Merge) {
                     start = existingMarker.start;
                     end = Math.max(end, existingMarker.end);
-                } else {
-                    this.#setSingleClass(this.#endTd, warnClass);
                 }
+            // {New---[Existing++}...] or [Existing...{New+++}...]
             } else if (end >= existingMarker.start && end <= existingMarker.end) {
                 isWarn = true;
                 semiWarn = false;
@@ -334,6 +339,14 @@ class BulkAddRow extends BulkActionRow {
                 if (resolveType == BulkMarkerResolveType.Merge) {
                     start = Math.min(start, existingMarker.start);
                 }
+
+                this.#startTd.classList.add(warnClass);
+            // {New---[Existing+++]---}
+            } else if (start <= existingMarker.start && end >= existingMarker.end) {
+                isWarn = true;
+                semiWarn = false;
+                this.#setClassBoth(warnClass);
+                tooltip += `<br>Overlaps with existing marker [${msToHms(existingMarker.start)}-${msToHms(existingMarker.end)}]`;
 
                 this.#startTd.classList.add(warnClass);
             } else if (end > this.#episodeInfo.duration) {

--- a/Client/Script/BulkAddOverlay.js
+++ b/Client/Script/BulkAddOverlay.js
@@ -85,6 +85,13 @@ class BulkAddOverlay {
                     0,
                     { keyup : this.#onBulkAddInputChange.bind(this) }
                 )),
+            appendChildren(buildNode('div', { id : 'bulkAddMarkerType' }),
+                buildNode('label', { for : 'markerTypeSelect' }, 'Marker Type: '),
+                appendChildren(
+                    buildNode('select', { id : 'markerTypeSelect' }),
+                    buildNode('option', { value : 'intro', selected : 'selected' }, 'Intro'),
+                    buildNode('option', { value : 'credits' }, 'Credits'))
+            ),
             appendChildren(buildNode('div', { id : 'bulkAddApplyType' }),
                 buildNode('label', { for : 'applyTypeSelect' }, 'Apply Action: '),
                 appendChildren(
@@ -140,12 +147,13 @@ class BulkAddOverlay {
         const startTime = this.startTime();
         const endTime = this.endTime();
         const resolveType = this.resolveType();
+        const markerType = this.markerType();
         if (isNaN(startTime) || isNaN(endTime)) {
             return BulkActionCommon.flashButton('bulkAddApply', 'red');
         }
 
         try {
-            const result = await ServerCommand.bulkAdd(MarkerType.Intro, this.#mediaItem.metadataId, startTime, endTime, resolveType, false /*final*/, this.#table?.getIgnored());
+            const result = await ServerCommand.bulkAdd(markerType, this.#mediaItem.metadataId, startTime, endTime, resolveType, false /*final*/, this.#table?.getIgnored());
             if (!result.applied) {
                 BulkActionCommon.flashButton('bulkAddApply', 'red', 250);
                 return;
@@ -238,6 +246,7 @@ class BulkAddOverlay {
     startTime() { return this.#cachedStart; }
     endTime() { return this.#cachedEnd; }
     resolveType() { return this.#cachedApplyType; }
+    markerType() { return $('#markerTypeSelect').value; } // TODO: store main container and scope to that.
 
     /** Update all items in the customization table, if present. */
     #updateTableStats() {
@@ -349,17 +358,27 @@ class BulkAddRow extends BulkActionRow {
                 tooltip += `<br>Overlaps with existing marker [${msToHms(existingMarker.start)}-${msToHms(existingMarker.end)}]`;
 
                 this.#startTd.classList.add(warnClass);
-            } else if (end > this.#episodeInfo.duration) {
-                isWarn = true;
-                if (!this.#endTd.classList.contains('bulkActionOff')) {
-                    semiWarn = true;
-                    this.#endTd.classList.add('bulkActionSemi');
-                }
-
-                tooltip += `<br>End exceeds episode duration of ${msToHms(this.#episodeInfo.duration)}.`;
-                end = this.#episodeInfo.duration;
-                start = Math.min(start, end);
             }
+        }
+        
+        if (end > this.#episodeInfo.duration) {
+            isWarn = true;
+            if (!this.#endTd.classList.contains('bulkActionOff')) {
+                semiWarn = true;
+                this.#endTd.classList.add('bulkActionSemi');
+            }
+
+            tooltip += `<br>End exceeds episode duration of ${msToHms(this.#episodeInfo.duration)}.`;
+            end = this.#episodeInfo.duration;
+            start = Math.min(start, end);
+        }
+
+        if (start >= this.#episodeInfo.duration) {
+            isWarn = true;
+            // setSingle instead of setBoth to ensure it overwrites anything set above.
+            this.#setSingleClass(this.#startTd, 'bulkActionOff');
+            this.#setSingleClass(this.#endTd, 'bulkActionOff');
+            tooltip = `<br>Marker is beyond the end of the episode.`;
         }
 
         if (tooltip.length != 0) {

--- a/Client/Script/BulkAddOverlay.js
+++ b/Client/Script/BulkAddOverlay.js
@@ -1,4 +1,4 @@
-import { BulkMarkerResolveType, MarkerData } from '../../Shared/PlexTypes.js';
+import { BulkMarkerResolveType, MarkerData, MarkerType } from '../../Shared/PlexTypes.js';
 
 import { BulkActionCommon, BulkActionRow, BulkActionTable, BulkActionType } from './BulkActionCommon.js';
 import ButtonCreator from './ButtonCreator.js';
@@ -145,7 +145,7 @@ class BulkAddOverlay {
         }
 
         try {
-            const result = await ServerCommand.bulkAdd(this.#mediaItem.metadataId, startTime, endTime, resolveType, this.#table?.getIgnored());
+            const result = await ServerCommand.bulkAdd(MarkerType.Intro, this.#mediaItem.metadataId, startTime, endTime, resolveType, false /*final*/, this.#table?.getIgnored());
             if (!result.applied) {
                 BulkActionCommon.flashButton('bulkAddApply', 'red', 250);
                 return;

--- a/Client/Script/Common.js
+++ b/Client/Script/Common.js
@@ -46,18 +46,20 @@ const ServerCommand = {
      * @param {number} metadataId
      * @param {number} start
      * @param {number} end
-     * @param {number} [final=0]
+     * @param {boolean} [final=false]
      * @returns {Promise<SerializedMarkerData>} */
-    add : async (markerType, metadataId, start, end, final=0) => jsonRequest('add', { metadataId: metadataId, start : start, end : end, type : markerType, final : final }),
+    add : async (markerType, metadataId, start, end, final=0) => jsonRequest('add', { metadataId: metadataId, start : start, end : end, type : markerType, final : final ? 1 : 0 }),
 
     /**
      * Edit an existing marker with the given id.
+     * @param {string} markerType
      * @param {number} id 
      * @param {number} start
      * @param {number} end 
      * @param {boolean} userCreated true if user created, false if Plex generated
+     * @param {boolean} [final=false]
      * @returns {Promise<SerializedMarkerData>} */
-    edit : async (id, start, end, userCreated) => jsonRequest('edit', { id : id, start : start, end : end, userCreated : userCreated ? 1 : 0 }),
+    edit : async (markerType, id, start, end, userCreated, final=0) => jsonRequest('edit', { id : id, start : start, end : end, userCreated : userCreated ? 1 : 0, type : markerType, final : final ? 1 : 0 }),
 
     /**
      * Delete the marker with the given id.

--- a/Client/Script/Common.js
+++ b/Client/Script/Common.js
@@ -100,7 +100,7 @@ const ServerCommand = {
      * Retrieve episode and marker information relevant to a bulk_add operation.
      * @param {number} id Show/Season metadata id.
      * @returns {Promise<SerializedBulkAddResult>} */
-    checkBulkAdd : async (id) => jsonRequest('bulk_add', { id : id, start : 0, end : 0, resolveType : BulkMarkerResolveType.DryRun, ignored : ''}),
+    checkBulkAdd : async (id) => jsonRequest('bulk_add', { id : id, start : 0, end : 0, resolveType : BulkMarkerResolveType.DryRun, ignored : '', type : 'intro', final : 0 }),
 
     /**
      * Bulk adds a marker to the given metadata id.
@@ -109,10 +109,10 @@ const ServerCommand = {
      * @param {number} start Start time of the marker, in milliseconds.
      * @param {number} end End time of the marker, in milliseconds.
      * @param {number} resolveType The BulkMarkerResolveType.
-     * @param {number} [final=0] Whether this is the last marker of the episode (credits only)
+     * @param {boolean} [final=false] Whether this is the last marker of the episode (credits only)
      * @param {number[]?} ignored The list of episode ids to ignore adding markers to.
      * @returns {Promise<SerializedBulkAddResult>} */
-    bulkAdd : async (markerType, id, start, end, resolveType, final=0, ignored=[]) => jsonRequest('bulk_add', { id : id, start : start, end : end, type : markerType, final : final, resolveType : resolveType, ignored : ignored.join(',')}),
+    bulkAdd : async (markerType, id, start, end, resolveType, final=false, ignored=[]) => jsonRequest('bulk_add', { id : id, start : start, end : end, type : markerType, final : final ? 1 : 0, resolveType : resolveType, ignored : ignored.join(',')}),
 
     /**
      * Retrieve markers for all episodes ids in `keys`.

--- a/Client/Script/Common.js
+++ b/Client/Script/Common.js
@@ -42,11 +42,13 @@ class FetchError extends Error {
 const ServerCommand = {
     /**
      * Add a marker to the Plex database
+     * @param {string} markerType
      * @param {number} metadataId
      * @param {number} start
      * @param {number} end
+     * @param {number} [final=0]
      * @returns {Promise<SerializedMarkerData>} */
-    add : async (metadataId, start, end) => jsonRequest('add', { metadataId: metadataId, start : start, end : end }),
+    add : async (markerType, metadataId, start, end, final=0) => jsonRequest('add', { metadataId: metadataId, start : start, end : end, type : markerType, final : final }),
 
     /**
      * Edit an existing marker with the given id.
@@ -100,13 +102,15 @@ const ServerCommand = {
 
     /**
      * Bulk adds a marker to the given metadata id.
+     * @param {string} markerType The type of marker (intro/credits)
      * @param {number} id Show/Season metadata id.
      * @param {number} start Start time of the marker, in milliseconds.
      * @param {number} end End time of the marker, in milliseconds.
      * @param {number} resolveType The BulkMarkerResolveType.
+     * @param {number} [final=0] Whether this is the last marker of the episode (credits only)
      * @param {number[]?} ignored The list of episode ids to ignore adding markers to.
      * @returns {Promise<SerializedBulkAddResult>} */
-    bulkAdd : async (id, start, end, resolveType, ignored=[]) => jsonRequest('bulk_add', { id : id, start : start, end : end, resolveType : resolveType, ignored : ignored.join(',')}),
+    bulkAdd : async (markerType, id, start, end, resolveType, final=0, ignored=[]) => jsonRequest('bulk_add', { id : id, start : start, end : end, type : markerType, final : final, resolveType : resolveType, ignored : ignored.join(',')}),
 
     /**
      * Retrieve markers for all episodes ids in `keys`.

--- a/Client/Script/MarkerEdit.js
+++ b/Client/Script/MarkerEdit.js
@@ -67,7 +67,8 @@ class MarkerEdit {
                 maxlength : 12,
                 class : 'timeInput',
                 placeholder : 'ms or mm:ss[.000]',
-                value : initialValue
+                value : initialValue,
+                autocomplete : 'off',
             },
             0,
             events,

--- a/Client/Script/MarkerEdit.js
+++ b/Client/Script/MarkerEdit.js
@@ -1,5 +1,5 @@
 import { $, $$, appendChildren, buildNode, clearEle, errorResponseOverlay, msToHms, ServerCommand, timeToMs } from "./Common.js";
-import { MarkerData } from "../../Shared/PlexTypes.js";
+import { MarkerData, MarkerType } from "../../Shared/PlexTypes.js";
 
 import Tooltip from "./inc/Tooltip.js";
 
@@ -158,7 +158,7 @@ class MarkerEdit {
         }
 
         try {
-            const rawMarkerData = await ServerCommand.add(metadataId, startTime, endTime);
+            const rawMarkerData = await ServerCommand.add(MarkerType.Intro, metadataId, startTime, endTime);
             const newMarker = new MarkerData().setFromJson(rawMarkerData);
             PlexClientState.GetState().getEpisode(newMarker.episodeId).addMarker(newMarker, this.markerRow.row());
         } catch (err) {

--- a/Client/Script/MarkerEdit.js
+++ b/Client/Script/MarkerEdit.js
@@ -38,6 +38,7 @@ class MarkerEdit {
         }
 
         this.editing = true;
+        this.#setMarkerType();
         this.#buildTimeEdit();
         this.#buildConfirmCancel();
         return true;
@@ -107,6 +108,24 @@ class MarkerEdit {
     }
 
     /**
+     * Set the first column to be the type of marker (e.g. 'Intro' or 'Credits') */
+    #setMarkerType() {
+        const span = this.markerRow.row().children[0];
+        clearEle(span);
+        const select = buildNode('select', { class : 'inlineMarkerType' });
+        for (const [title, value] of Object.entries(MarkerType)) {
+            const option = buildNode('option', { value : value }, title);
+            if (value == this.markerRow.markerType()) {
+                option.selected = true;
+            }
+
+            select.appendChild(option);
+        }
+
+        span.appendChild(select);
+    }
+
+    /**
      * Replace the static marker start/end times with editable text fields. */
     #buildTimeEdit() {
         let start = this.markerRow.row().children[1];
@@ -148,17 +167,19 @@ class MarkerEdit {
      * Attempts to add a marker to the database, first validating that the marker is valid.
      * On success, make the temporary row permanent and rearrange the markers based on their start time. */
     async onMarkerAddConfirm() {
+        const markerType = $$('.inlineMarkerType', this.markerRow.row()).value;
         const inputs = $('input[type="text"]', this.markerRow.row());
         const startTime = timeToMs(inputs[0].value);
         const endTime = timeToMs(inputs[1].value);
         const metadataId = this.markerRow.episodeId();
         const episode = PlexClientState.GetState().getEpisode(metadataId);
+        const final = endTime == episode.duration && markerType == MarkerType.Credits;
         if (!episode.checkValues(this.markerRow.markerId(), startTime, endTime)) {
             return;
         }
 
         try {
-            const rawMarkerData = await ServerCommand.add(MarkerType.Intro, metadataId, startTime, endTime);
+            const rawMarkerData = await ServerCommand.add(markerType, metadataId, startTime, endTime, final);
             const newMarker = new MarkerData().setFromJson(rawMarkerData);
             PlexClientState.GetState().getEpisode(newMarker.episodeId).addMarker(newMarker, this.markerRow.row());
         } catch (err) {
@@ -173,6 +194,7 @@ class MarkerEdit {
 
     /** Commits a marker edit, assuming it passes marker validation. */
     async onMarkerEditConfirm() {
+        const markerType = $$('.inlineMarkerType', this.markerRow.row()).value;
         const inputs = $('input[type="text"]', this.markerRow.row());
         const startTime = timeToMs(inputs[0].value);
         const endTime = timeToMs(inputs[1].value);
@@ -180,12 +202,13 @@ class MarkerEdit {
         const episode = PlexClientState.GetState().getEpisode(metadataId);
         const userCreated = this.markerRow.createdByUser();
         const markerId = this.markerRow.markerId();
+        const final = endTime == episode.duration && markerType == MarkerType.Credits;
         if (!episode.checkValues(markerId, startTime, endTime)) {
             return;
         }
 
         try {
-            const rawMarkerData = await ServerCommand.edit(markerId, startTime, endTime, userCreated);
+            const rawMarkerData = await ServerCommand.edit(markerType, markerId, startTime, endTime, userCreated, final);
             const editedMarker = new MarkerData().setFromJson(rawMarkerData);
             PlexClientState.GetState().getEpisode(editedMarker.episodeId).editMarker(editedMarker);
             this.resetAfterEdit();
@@ -229,6 +252,9 @@ class MarkerEdit {
 
         e.preventDefault();
         input.value = msToHms(PlexClientState.GetState().getEpisode(this.markerRow.episodeId()).duration);
+
+        // Assume credits if they enter the end of the episode.
+        $$('.inlineMarkerType', this.markerRow.row()).value = 'credits';
     }
 }
 

--- a/Client/Script/MarkerTable.js
+++ b/Client/Script/MarkerTable.js
@@ -161,9 +161,7 @@ class MarkerTable {
                 marker.start = partialMarker.start;
                 marker.end = partialMarker.end;
 
-                // This won't match the YYYY-MM-DD hh:mm:ssZ returned by the database, but
-                // we just need a valid UTC string for client-side parsing.
-                marker.modifiedDate = new Date().toUTCString();
+                marker.modifiedDate = Date.now() / 1000; // DB stores seconds, JS does ms.
                 break;
             }
         }

--- a/Client/Script/MarkerTableRow.js
+++ b/Client/Script/MarkerTableRow.js
@@ -1,6 +1,6 @@
 
 import { $, $$, appendChildren, buildNode, clearEle, errorResponseOverlay, ServerCommand } from "./Common.js";
-import { MarkerData } from "../../Shared/PlexTypes.js";
+import { MarkerData, MarkerType } from "../../Shared/PlexTypes.js";
 
 import Overlay from "./inc/Overlay.js";
 
@@ -63,11 +63,11 @@ class MarkerRow {
     /** Returns the marker id for this marker, if it's an edit of an existing marker. */
     markerId() { return -1; }
 
+    /** Returns the type of this marker. */
+    markerType() { return 'intro'; }
+
     /** Return whether this marker was originally created by Plex automatically, or by the user. */
     createdByUser() { return true; }
-
-    /** Return the index of this marker in the marker table, or -1 if {@linkcode forAdd} is true. */
-    rowIndex() { return -1; }
 
     /** Resets this marker row after an edit is completed (on success or failure). */
     reset() {}
@@ -88,8 +88,8 @@ class ExistingMarkerRow extends MarkerRow {
     startTime() { return this.#markerData.start; }
     endTime() { return this.#markerData.end; }
     markerId() { return this.#markerData.id; }
+    markerType() { return this.#markerData.markerType; }
     createdByUser() { return this.#markerData.createdByUser; }
-    rowIndex() { return this.#markerData.index; }
     reset() {
         const children = this.#tableData(!!$$('.markerOptionsHolder', this.html));
         for (let i = 0; i < children.length; ++i) {
@@ -129,7 +129,7 @@ class ExistingMarkerRow extends MarkerRow {
     #tableData(includeOptions) {
 
         let data = [
-            this.#markerData.index.toString(),
+            Object.keys(MarkerType).find(k => MarkerType[k] == this.#markerData.markerType),
             TableElements.timeData(this.#markerData.start),
             TableElements.timeData(this.#markerData.end),
             TableElements.friendlyDate(this.#markerData)

--- a/Client/Script/PurgedMarkerManager.js
+++ b/Client/Script/PurgedMarkerManager.js
@@ -402,7 +402,9 @@ class PurgeNonActionInfo {
             episode_id : this.#markerAction.episode_id,
             season_id : this.#markerAction.season_id,
             show_id : this.#markerAction.show_id,
-            section_id : PlexClientState.GetState().activeSection()
+            section_id : PlexClientState.GetState().activeSection(),
+            marker_type : this.#markerAction.marker_type,
+            final : this.#markerAction.final,
         };
 
         return new MarkerData(rawMarkerData);

--- a/Client/Script/ResultRow.js
+++ b/Client/Script/ResultRow.js
@@ -514,7 +514,7 @@ class SeasonResultRow extends ResultRow {
     notifyBulkAction(changedMarkers, bulkActionType) {
         // Sort by index high to low to to avoid the marker table from
         // getting indexes out of sync.
-        changedMarkers.sort((a, b) => b.index - a.index);
+        changedMarkers.sort((a, b) => b.start - a.start);
         for (const marker of changedMarkers) {
             const episode = this.#episodes[marker.episodeId];
             if (!episode) {

--- a/Client/Script/TableElements.js
+++ b/Client/Script/TableElements.js
@@ -91,7 +91,7 @@ class TableElements {
      * Return a span that contains a "friendly" date (x [time span] ago), with a tooltip of the exact date.
      * @param {MarkerData} marker The marker being displayed. */
     static friendlyDate(marker) {
-        const createDate = DateUtil.getDisplayDate(marker.createDate);
+        const createDate = DateUtil.getDisplayDate(marker.createDate * 1000); // Seconds to ms
         let node = buildNode('span', { class : marker.modifiedDate ? 'userModifiedMarker' : '' }, createDate);
         Tooltip.setTooltip(node, TableElements.#dateTooltip(marker));
         return node;
@@ -117,7 +117,7 @@ class TableElements {
      * Creates a tooltip for a friendly date, which includes the create date and the last edited date (if any).
      * @param {MarkerData} marker */
     static #dateTooltip(marker) {
-        const fullCreateDate = DateUtil.getFullDate(marker.createDate);
+        const fullCreateDate = DateUtil.getFullDate(marker.createDate * 1000); // s to ms
         if (!marker.modifiedDate) {
             return `Automatically created on ${fullCreateDate}`;
         }
@@ -127,7 +127,7 @@ class TableElements {
         }
 
         const who = marker.createdByUser ? 'Manually' : 'Automatically';
-        return `${who} added on ${fullCreateDate}<br>Modified by user on ${DateUtil.getFullDate(marker.modifiedDate)}`;
+        return `${who} added on ${fullCreateDate}<br>Modified by user on ${DateUtil.getFullDate(marker.modifiedDate * 1000)}`;
     }
 }
 

--- a/Server/DatabaseWrapper.js
+++ b/Server/DatabaseWrapper.js
@@ -111,6 +111,8 @@ class DatabaseWrapper {
                 newQuery += `"${parameter.replaceAll('"', '""')}"`;
             } else if (typeof parameter === 'number') {
                 newQuery += parameter.toString();
+            } else if (typeof parameter === 'boolean') {
+                newQuery += parameter ? '1' : '0';
             } else {
                 throw new ServerError(`Unable to parameterize query, only expected strings and numbers, found ${typeof parameter}`, 500);
             }

--- a/Server/MarkerBackupManager.js
+++ b/Server/MarkerBackupManager.js
@@ -539,7 +539,7 @@ class MarkerBackupManager {
             const modified = 'CURRENT_TIMESTAMP' + (marker.createdByUser ? ' || "*"' : '');
             const query = `
     INSERT INTO actions
-    (op, marker_id, episode_id, season_id, show_id, section_id, start, end, old_start, old_end, modified_at, created_at, extra_data, section_uuid, episode_guid) VALUES
+    (op, marker_id, episode_id, season_id, show_id, section_id, start, end, old_start, old_end, modified_at, created_at, extra_data, section_uuid, episode_guid, marker_type, final) VALUES
     (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ${modified}, ?, ?, ?, ?, ?, ?)`;
             const parameters = [MarkerOp.Edit, marker.id, marker.episodeId, marker.seasonId, marker.showId, marker.sectionId, marker.start, marker.end, oldTimings.start, oldTimings.end, marker.createDate,
                 this.#extraDataFromMarkerType(marker), this.#uuids[marker.sectionId], marker.episodeGuid, marker.markerType, marker.isFinal];
@@ -572,7 +572,7 @@ class MarkerBackupManager {
             const modified = 'CURRENT_TIMESTAMP' + (marker.createdByUser ? ' || "*"' : '');
             const query = `
     INSERT INTO actions
-    (op, marker_id, episode_id, season_id, show_id, section_id, start, end, modified_at, created_at, extra_data, section_uuid, episode_guid) VALUES
+    (op, marker_id, episode_id, season_id, show_id, section_id, start, end, modified_at, created_at, extra_data, section_uuid, episode_guid, marker_type, final) VALUES
     (?, ?, ?, ?, ?, ?, ?, ?, ${modified}, ?, ?, ?, ?, ?, ?)`;
             const parameters = [MarkerOp.Delete, marker.id, marker.episodeId, marker.seasonId, marker.showId, marker.sectionId, marker.start, marker.end,
                 marker.createDate, this.#extraDataFromMarkerType(marker), this.#uuids[marker.sectionId], marker.episodeGuid, marker.markerType, marker.isFinal];
@@ -601,7 +601,7 @@ class MarkerBackupManager {
         for (const restore of restores) {
             const query = `
                 INSERT INTO actions
-                (op, marker_id, episode_id, season_id, show_id, section_id, start, end, modified_at, created_at, extra_data, section_uuid, restores_id, episode_guid) VALUES
+                (op, marker_id, episode_id, season_id, show_id, section_id, start, end, modified_at, created_at, extra_data, section_uuid, restores_id, episode_guid, marker_type, final) VALUES
                 (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);\n`;
 
             const m = new MarkerData(restore.marker);

--- a/Server/PlexQueryManager.js
+++ b/Server/PlexQueryManager.js
@@ -346,12 +346,15 @@ ORDER BY e.\`index\` ASC;`;
 
     /**
      * Does some post-processing on the given marker data to extract relevant fields.
-     * @param {RawMarkerData[]} markerData */
+     * @param {RawMarkerData[]|RawMarkerData} markerData */
     async #postProcessExtendedMarkerFields(markerData) {
-        for (const marker of markerData) {
+        let markerArray = markerData ? (markerData instanceof Array) ? markerData : [markerData] : [];
+        for (const marker of markerArray) {
             marker.final = marker.extra_data.indexOf('final=1') != -1;
             delete marker.extra_data;
         }
+
+        return markerData;
     }
 
     /**
@@ -449,9 +452,9 @@ ORDER BY e.\`index\` ASC;`;
      * @param {number} markerId
      * @returns {Promise<RawMarkerData>} */
     async getSingleMarker(markerId) {
-        return this.#postProcessExtendedMarkerFields([await this.#database.get(
+        return this.#postProcessExtendedMarkerFields(await this.#database.get(
             `SELECT ${this.#extendedMarkerFields} WHERE taggings.id=? AND taggings.tag_id=?;`,
-            [markerId, this.#markerTagId])]);
+            [markerId, this.#markerTagId]));
     }
 
     /**
@@ -686,9 +689,9 @@ ORDER BY e.\`index\` ASC;`;
      * @param {number} index The index of the marker in the marker table.
      * @returns {Promise<RawMarkerData>} */
     async getNewMarker(metadataId, startMs, endMs) {
-        return this.#postProcessExtendedMarkerFields([await this.#database.get(
+        return this.#postProcessExtendedMarkerFields(await this.#database.get(
             `SELECT ${this.#extendedMarkerFields} WHERE metadata_item_id=? AND tag_id=? AND taggings.time_offset=? AND taggings.end_time_offset=?;`,
-            [metadataId, this.#markerTagId, startMs, endMs])]);
+            [metadataId, this.#markerTagId, startMs, endMs]));
     }
 
     /**

--- a/Server/PlexQueryManager.js
+++ b/Server/PlexQueryManager.js
@@ -942,9 +942,10 @@ ORDER BY e.id ASC;`;
         for (const episodeId of episodeIds) {
             if (ignoredEpisodes.has(episodeId)) { continue; }
             const episodeEnd = Math.min(episodeMarkerMap[episodeId].episodeData.duration, baseEnd);
+            const finalActual = markerType === MarkerType.Credits && (final || baseEnd >= episodeEnd);
             const episodeMarkers = episodeMarkerMap[episodeId].existingMarkers;
             if (!episodeMarkers || episodeMarkers.length == 0) {
-                this.#addMarkerStatement(transaction, episodeId, 0 /*newIndex*/, baseStart, episodeEnd, markerType, final);
+                this.#addMarkerStatement(transaction, episodeId, 0 /*newIndex*/, baseStart, episodeEnd, markerType, finalActual);
                 plainAdd.add(episodeId);
                 episodeMarkerMap[episodeId].isAdd = true;
                 continue;
@@ -956,7 +957,7 @@ ORDER BY e.id ASC;`;
                 if (episodeMarker.end < baseStart) {
                     if (i == episodeMarkers.length - 1) {
                         // We're adding beyond the last marker
-                        this.#addMarkerStatement(transaction, episodeId, episodeMarkers.length, baseStart, episodeEnd, markerType, final);
+                        this.#addMarkerStatement(transaction, episodeId, episodeMarkers.length, baseStart, episodeEnd, markerType, finalActual);
                         plainAdd.add(episodeId);
                         episodeMarkerMap[episodeId].isAdd = true;
                     }
@@ -989,7 +990,7 @@ ORDER BY e.id ASC;`;
                     break;
                 }
 
-                this.#addMarkerStatement(transaction, episodeId, i, baseStart, episodeEnd, markerType, final);
+                this.#addMarkerStatement(transaction, episodeId, i, baseStart, episodeEnd, markerType, finalActual);
                 episodeMarkerMap[episodeId].isAdd = true;
                 plainAdd.add(episodeId);
                 break;

--- a/Server/ServerCommands.js
+++ b/Server/ServerCommands.js
@@ -12,7 +12,7 @@ class ServerCommands {
     * Map endpoints to their corresponding functions. Also breaks out and validates expected query parameters.
     * @type {{[endpoint: string]: (params : QueryParser) => Promise<any>}} */
     static #commandMap = {
-        add           : async (params) => await CoreCommands.addMarker(...params.ints('metadataId', 'start', 'end')),
+        add           : async (params) => await CoreCommands.addMarker(params.raw('type'), ...params.ints('metadataId', 'start', 'end', 'final')),
         edit          : async (params) => await CoreCommands.editMarker(...params.ints('id', 'start', 'end', 'userCreated')),
         delete        : async (params) => await CoreCommands.deleteMarker(params.i('id')),
         check_shift   : async (params) => await CoreCommands.shiftMarkers(params.i('id'), 0, 0, ShiftApplyType.DontApply, []),
@@ -21,7 +21,7 @@ class ServerCommands {
                                                                 params.i('force') ? ShiftApplyType.ForceApply : ShiftApplyType.TryApply,
                                                                 params.ia('ignored', true)),
         bulk_delete   : async (params) => await CoreCommands.bulkDelete(params.i('id'), params.i('dryRun'), params.ia('ignored', true)),
-        bulk_add      : async (params) => await CoreCommands.bulkAdd(...params.ints('id', 'start', 'end', 'resolveType'), params.ia('ignored')),
+        bulk_add      : async (params) => await CoreCommands.bulkAdd(params.raw('type'), ...params.ints('id', 'start', 'end', 'final', 'resolveType'), params.ia('ignored')),
 
 
         query         : async (params) => await QueryCommands.queryIds(params.ia('keys')),

--- a/Server/ServerCommands.js
+++ b/Server/ServerCommands.js
@@ -13,7 +13,7 @@ class ServerCommands {
     * @type {{[endpoint: string]: (params : QueryParser) => Promise<any>}} */
     static #commandMap = {
         add           : async (params) => await CoreCommands.addMarker(params.raw('type'), ...params.ints('metadataId', 'start', 'end', 'final')),
-        edit          : async (params) => await CoreCommands.editMarker(...params.ints('id', 'start', 'end', 'userCreated')),
+        edit          : async (params) => await CoreCommands.editMarker(params.raw('type'), ...params.ints('id', 'start', 'end', 'userCreated', 'final')),
         delete        : async (params) => await CoreCommands.deleteMarker(params.i('id')),
         check_shift   : async (params) => await CoreCommands.shiftMarkers(params.i('id'), 0, 0, ShiftApplyType.DontApply, []),
         shift         : async (params) => await CoreCommands.shiftMarkers(

--- a/Shared/PlexTypes.js
+++ b/Shared/PlexTypes.js
@@ -10,7 +10,7 @@
  * @typedef {{[metadataId: number]: EpisodeData}} EpisodeMap A map of episode metadata ids to the episode itself.
  * @typedef {{metadataId : number, markerBreakdown? : MarkerBreakdownMap}} PlexDataBaseData
  * @typedef {{start: number, end: number, index: number, id: number, episodeId: number,
- *            seasonId: number, showId: number, sectionId: number}} SerializedMarkerData
+ *            seasonId: number, showId: number, sectionId: number, markerType: string, isFinal: boolean}} SerializedMarkerData
  * @typedef {{metadataId: number, markerBreakdown: MarkerBreakdownMap, title: string, searchTitle: string,
  *            sortTitle: string, originalTitle: string, seasonCount: number, episodeCount: number }} SerializedShowData
  * @typedef {{metadataId: number, markerBreakdown: MarkerBreakdownMap, index: number, title: string, episodeCount: number }} SerializedSeasonData
@@ -315,6 +315,16 @@ class EpisodeData extends PlexData {
 }
 
 /**
+ * Possible marker types
+ * @enum */
+const MarkerType = {
+    /** @readonly */
+    Intro   : 'intro',
+    /** @readonly */
+    Credits : 'credits',
+}
+
+/**
  * Information about a single marker for an episode of a TV show in the Plex database.
  */
 class MarkerData extends PlexData {
@@ -379,6 +389,17 @@ class MarkerData extends PlexData {
     episodeGuid;
 
     /**
+     * The type of marker this represents.
+     * @type {[keyof MarkerType]} */
+    markerType;
+
+    /**
+     * Whether this marker extends to the end of the movie/episode
+     * Only applies if type == MarkerType.Credits
+     * @type {boolean} */
+    isFinal;
+
+    /**
      * Creates a new MarkerData from the given marker, if provided.
      * @param {Object<string, any>} [marker] */
     constructor(marker) {
@@ -418,6 +439,8 @@ class MarkerData extends PlexData {
         this.showId = marker.show_id;
         this.sectionId = marker.section_id;
         this.episodeGuid = marker.episode_guid;
+        this.markerType = marker.marker_type;
+        this.isFinal = this.type == MarkerType.Credits && marker.final;
     }
 }
 
@@ -434,4 +457,4 @@ const BulkMarkerResolveType = {
     Ignore : 3,
 };
 
-export { BulkMarkerResolveType, PlexData, ShowData, SeasonData, EpisodeData, MarkerData }
+export { BulkMarkerResolveType, PlexData, ShowData, SeasonData, EpisodeData, MarkerData, MarkerType }

--- a/Shared/PlexTypes.js
+++ b/Shared/PlexTypes.js
@@ -344,8 +344,8 @@ class MarkerData extends PlexData {
     index;
 
     /**
-     * The date the marker was modified by the user.
-     * @type {string} */
+     * The date the marker was modified by the user (epoch).
+     * @type {number} */
     modifiedDate;
 
     /**
@@ -354,8 +354,8 @@ class MarkerData extends PlexData {
     createdByUser;
 
     /**
-     * The date the marker was created.
-     * @type {string} */
+     * The date the marker was created (epoch).
+     * @type {number} */
     createDate;
 
     /**
@@ -413,25 +413,17 @@ class MarkerData extends PlexData {
         this.index = marker.index;
 
         if (marker.modified_date) {
-            let modified = marker.modified_date;
-            // Check to see if it has a 'user created' flag.
+            this.modifiedDate = marker.modified_date;
+
             // For legacy purposes, also check whether the create date equals the modified date,
             // as previous versions of this application didn't include the 'manually created' marker.
-            this.createdByUser = modified[modified.length - 1] == '*' || modified == marker.created_at;
-
-            // Modified date is stored as a UTC timestamp, but JS date functions don't know without the 'Z'.
-            this.modifiedDate = modified.substring(0, modified.length - 1);
-            if (!this.modifiedDate.endsWith('Z')) {
-                this.modifiedDate += 'Z';
-            }
+            this.createdByUser = marker.user_created || this.modifiedDate == marker.created_at;
         } else {
             this.createdByUser = false;
             this.modifiedDate = '';
         }
 
-        // Plex stores timestamps in local time for some reason, so only "convert" to UTC time
-        // if the marker was created by the user.
-        this.createDate = marker.created_at + ((this.createdByUser && !marker.created_at.endsWith('Z')) ? 'Z' : '');
+        this.createDate = marker.created_at;
 
         this.id = marker.id;
         this.episodeId = marker.episode_id;

--- a/Test/TestBase.js
+++ b/Test/TestBase.js
@@ -13,7 +13,7 @@ import { run as mainRun } from "../Server/IntroEditor.js";
 import { TestLog } from './TestRunner.js';
 import DatabaseWrapper from '../Server/DatabaseWrapper.js';
 import { ServerState, GetServerState } from '../Server/ServerState.js';
-import { ExtraData } from '../Server/MarkerBackupManager.js';
+import { ExtraData } from '../Server/PlexQueryManager.js';
 /** @typedef {!import('../Shared/PlexTypes.js').SerializedMarkerData} SerializedMarkerData */
 
 /**
@@ -436,7 +436,9 @@ class TestBase {
         return this.send('add', {
             metadataId : episodeId,
             start : startMs,
-            end : endMs
+            end : endMs,
+            type : 'intro', // TODO: credits
+            final : 0, // TODO: credits
         }, raw);
     }
 

--- a/Test/TestBase.js
+++ b/Test/TestBase.js
@@ -388,7 +388,7 @@ class TestBase {
             INSERT INTO taggings
                 (metadata_item_id, tag_id, "index", text, time_offset, end_time_offset, created_at, extra_data)
             VALUES
-                (${metadataId}, 1, ${index}, "${markerType}", ${start}, ${end}, CURRENT_TIMESTAMP, "${markerType == 'intro' ? ExtraData.Intro : isFinal ? ExtraData.CreditsFinal : ExtraData.Credits}");\n`;
+                (${metadataId}, 1, ${index}, "${markerType}", ${start}, ${end}, (strftime('%s','now')), "${markerType == 'intro' ? ExtraData.Intro : isFinal ? ExtraData.CreditsFinal : ExtraData.Credits}");\n`;
 
 
         let insertString = '';

--- a/Test/TestBase.js
+++ b/Test/TestBase.js
@@ -278,7 +278,8 @@ class TestBase {
     }
 
     /**
-     * Map of default metadata items to their metadata/marker ids. */
+     * Map of default metadata items to their metadata/marker ids.
+     * TODO: indexRemove: Replace Index with Order? Still want to test reordering, but via our calculated values. */
     static DefaultMetadata = {
         Show1 : { Id : 1,
             Season1 : { Id : 2,

--- a/Test/TestClasses/BasicCRUDTest.js
+++ b/Test/TestClasses/BasicCRUDTest.js
@@ -32,12 +32,14 @@ class BasicCRUD extends TestBase {
 
         return TestHelpers.validateMarker(
             marker,
+            'intro' /*expectedType*/,
             show.Season1.Episode1.Id,
             show.Season1.Id,
             show.Id,
             0 /*expectedStart*/,
             1000 /*expectedEnd*/,
             0 /*expectedIndex*/,
+            false /*expectedFinal*/,
             this.testDb);
     }
 
@@ -105,12 +107,14 @@ class BasicCRUD extends TestBase {
 
         // Edit returns modified data
         return TestHelpers.validateMarker(marker,
+            'intro' /*expectedType*/,
             show.Season1.Episode2.Id,
             show.Season1.Id,
             show.Id,
             14000 /*expectedStart*/,
             46000 /*expectedEnd*/,
             0 /*expectedIndex*/,
+            false /*expectedFinal*/,
             this.testDb);
     }
 
@@ -146,12 +150,14 @@ class BasicCRUD extends TestBase {
         });
 
         return TestHelpers.validateMarker(marker,
+            'intro' /*expectedType*/,
             show.Season1.Episode2.Id,
             show.Season1.Id,
             show.Id,
             15000 /*expectedStart*/,
             45000 /*expectedEnd*/,
             0 /*expectedIndex*/,
+            false /*expectedFinal*/,
             this.testDb,
             true /*isDeleted*/);
     }

--- a/Test/TestClasses/BulkAddTest.js
+++ b/Test/TestClasses/BulkAddTest.js
@@ -41,7 +41,7 @@ class BulkAddTest extends TestBase {
             [],
             true,
             false,
-            [   { id : 6, start : 0, end : 10000, index : 0},
+            [   { id : 7, start : 0, end : 10000, index : 0},
                 { id : episode.Marker1.Id, start : episode.Marker1.Start, end : episode.Marker1.End, index : 1 }
             ],
             {}
@@ -53,11 +53,12 @@ class BulkAddTest extends TestBase {
     async easyBulkAddSeasonTest() {
         const season = TestBase.DefaultMetadata.Show3.Season1;
         let expectedMarkers = [
-            { id : 6, start : 0, end : 10000, index : 0 },
             { id : 7, start : 0, end : 10000, index : 0 },
+            { id : 8, start : 0, end : 10000, index : 0 },
             this.#testMarkerFromTestData(season.Episode1.Marker1, 1),
             this.#testMarkerFromTestData(season.Episode2.Marker1, 1),
-            this.#testMarkerFromTestData(season.Episode2.Marker2, 2)
+            this.#testMarkerFromTestData(season.Episode2.Marker2, 2),
+            this.#testMarkerFromTestData(season.Episode2.Marker3, 3),
         ];
         return this.#verifyBulkAdd(
             season.Id,
@@ -79,12 +80,13 @@ class BulkAddTest extends TestBase {
         const newStart = 50000;
         const newEnd = 70000;
         let expectedMarkers = [
-            { id : 6, start : newStart, end : newEnd, index : 1 },
             { id : 7, start : newStart, end : newEnd, index : 1 },
             { id : 8, start : newStart, end : newEnd, index : 1 },
+            { id : 9, start : newStart, end : newEnd, index : 1 },
             this.#testMarkerFromTestData(show.Season1.Episode1.Marker1, 0),
             this.#testMarkerFromTestData(show.Season1.Episode2.Marker1, 0),
             this.#testMarkerFromTestData(show.Season1.Episode2.Marker2, 2),
+            this.#testMarkerFromTestData(show.Season1.Episode2.Marker3, 3),
             this.#testMarkerFromTestData(show.Season2.Episode1.Marker1, 0),
         ];
         return this.#verifyBulkAdd(
@@ -108,7 +110,8 @@ class BulkAddTest extends TestBase {
         let expectedMarkers = [
             this.#testMarkerFromTestData(season.Episode1.Marker1, 0),
             this.#testMarkerFromTestData(season.Episode2.Marker1, 0),
-            this.#testMarkerFromTestData(season.Episode2.Marker2, 1)
+            this.#testMarkerFromTestData(season.Episode2.Marker2, 1),
+            this.#testMarkerFromTestData(season.Episode2.Marker3, 2),
         ];
         return this.#verifyBulkAdd(
             season.Id,
@@ -131,10 +134,11 @@ class BulkAddTest extends TestBase {
         const newStart = 300000;
         const newEnd = 350000;
         let expectedMarkers = [
-            { id : 6, start : newStart, end : newEnd, index : 1 },
+            { id : 7, start : newStart, end : newEnd, index : 1 },
             this.#testMarkerFromTestData(season.Episode1.Marker1, 0),
             this.#testMarkerFromTestData(season.Episode2.Marker1, 0),
-            this.#testMarkerFromTestData(season.Episode2.Marker2, 1)
+            this.#testMarkerFromTestData(season.Episode2.Marker2, 1),
+            this.#testMarkerFromTestData(season.Episode2.Marker3, 2),
         ];
         return this.#verifyBulkAdd(
             season.Id,
@@ -157,10 +161,11 @@ class BulkAddTest extends TestBase {
         const newStart = 330000;
         const newEnd = 350000;
         let expectedMarkers = [
-            { id : 6, start : newStart, end : newEnd, index : 1 },
+            { id : 7, start : newStart, end : newEnd, index : 1 },
             this.#testMarkerFromTestData(season.Episode1.Marker1, 0),
             this.#testMarkerFromTestData(season.Episode2.Marker1, 0),
-            this.#testMarkerFromTestData(season.Episode2.Marker2, 1, 300000, newEnd)
+            this.#testMarkerFromTestData(season.Episode2.Marker2, 1, 300000, newEnd),
+            this.#testMarkerFromTestData(season.Episode2.Marker3, 2),
         ];
         return this.#verifyBulkAdd(
             season.Id,
@@ -185,6 +190,7 @@ class BulkAddTest extends TestBase {
         let expectedMarkers = [
             this.#testMarkerFromTestData(season.Episode1.Marker1, 0, 15000, newEnd),
             this.#testMarkerFromTestData(season.Episode2.Marker1, 0, 15000, newEnd),
+            this.#testMarkerFromTestData(season.Episode2.Marker3, 1),
         ];
         return this.#verifyBulkAdd(
             season.Id,
@@ -209,6 +215,7 @@ class BulkAddTest extends TestBase {
         let expectedMarkers = [
             this.#testMarkerFromTestData(season.Episode1.Marker1, 0, newStart, newEnd),
             this.#testMarkerFromTestData(season.Episode2.Marker1, 0, newStart, newEnd),
+            this.#testMarkerFromTestData(season.Episode2.Marker3, 1),
         ];
         return this.#verifyBulkAdd(
             season.Id,
@@ -232,10 +239,11 @@ class BulkAddTest extends TestBase {
         const newStart = 330000;
         const newEnd = 350000;
         let expectedMarkers = [
-            { id : 6, start : newStart, end : newEnd, index : 1 },
+            { id : 7, start : newStart, end : newEnd, index : 1 },
             this.#testMarkerFromTestData(season.Episode1.Marker1, 0),
             this.#testMarkerFromTestData(season.Episode2.Marker1, 0),
             this.#testMarkerFromTestData(season.Episode2.Marker2, 1),
+            this.#testMarkerFromTestData(season.Episode2.Marker3, 2),
         ];
         return this.#verifyBulkAdd(
             season.Id,
@@ -263,7 +271,7 @@ class BulkAddTest extends TestBase {
             [],
             true,
             false,
-            [   { id : 6, start : 50000, end : 600000, index : 1},
+            [   { id : 7, start : 50000, end : 600000, index : 1},
                 this.#testMarkerFromTestData(episode.Marker1, 0)
             ],
             {}
@@ -323,7 +331,7 @@ class BulkAddTest extends TestBase {
         TestHelpers.verify(totalMarkerCount == expectedMarkerCount, `Expected to find ${expectedMarkerCount} markers after bulk action, found ${totalMarkerCount}`);
 
         for (const marker of markersToCheck) {
-            await TestHelpers.validateMarker(marker, null, null, null, marker.start, marker.end, marker.index, this.testDb, marker.deleted);
+            await TestHelpers.validateMarker(marker, null, null, null, null, marker.start, marker.end, marker.index, null, this.testDb, marker.deleted);
         }
     }
 }

--- a/Test/TestClasses/BulkAddTest.js
+++ b/Test/TestClasses/BulkAddTest.js
@@ -303,8 +303,8 @@ class BulkAddTest extends TestBase {
     async #verifyBulkAdd(metadataId, start, end, resolveType, ignored, expectApply, expectConflict, markersToCheck, expectedDeletes={}) {
         let totalMarkerCount = 0;
         const expectedMarkerCount = markersToCheck.reduce((sum, marker) => sum + (marker.deleted ? 0 : 1), 0);
-        /** @type {SerializedBulkAddResult} */
-        const result = await this.send('bulk_add', { id : metadataId, start : start, end : end, resolveType : resolveType, ignored : ignored.join(',') });
+        /** @type {SerializedBulkAddResult} // TODO: credits */
+        const result = await this.send('bulk_add', { id : metadataId, start : start, end : end, type : 'intro', final : 0, resolveType : resolveType, ignored : ignored.join(',') });
         Log.info(result);
         TestHelpers.verify(result, `Expected success response from bulk_add, found ${result}.`);
         TestHelpers.verify(result.applied === true || result.applied === false, `Expected result.applied to be true or false, found ${result.applied}`);

--- a/Test/TestClasses/BulkDeleteTest.js
+++ b/Test/TestClasses/BulkDeleteTest.js
@@ -31,7 +31,7 @@ class BulkDeleteTest extends TestBase {
         let response = await this.#bulkDelete(episode.Id, true);
         let length = (response && response.markers) ? response.markers.length : undefined;
         TestHelpers.verify(length == 1, `Expected 1 marker in dry run, found ${length}`);
-        await TestHelpers.validateMarker(response.markers[0], episode.Id, null, null, episode.Marker1.Start, episode.Marker1.End, episode.Marker1.Index, this.testDb);
+        await TestHelpers.validateMarker(response.markers[0], 'intro', episode.Id, null, null, episode.Marker1.Start, episode.Marker1.End, episode.Marker1.Index, episode.Marker1.Final, this.testDb);
         TestHelpers.verify(response.episodeData && response.episodeData[episode.Id], `Expected dry run to have episode data for ${episode.Id}, didn't find any.`);
         length = response.deletedMarkers ? response.deletedMarkers.length : undefined;
         TestHelpers.verify(length === 0, `Dry run should never have deleted markers, found ${length}`);
@@ -40,9 +40,12 @@ class BulkDeleteTest extends TestBase {
         episode = TestBase.DefaultMetadata.Show3.Season1.Episode2;
         response = await this.#bulkDelete(episode.Id, true);
         length = (response && response.markers) ? response.markers.length : undefined;
-        TestHelpers.verify(length == 2, `Expected 2 markers in dry run, found ${length}`);
-        await TestHelpers.validateMarker(response.markers[0], episode.Id, null, null, episode.Marker1.Start, episode.Marker1.End, episode.Marker1.Index, this.testDb);
-        await TestHelpers.validateMarker(response.markers[1], episode.Id, null, null, episode.Marker2.Start, episode.Marker2.End, episode.Marker2.Index, this.testDb);
+        TestHelpers.verify(length == 3, `Expected 3 markers in dry run, found ${length}`);
+        await TestHelpers.validateMarker(response.markers[0], episode.Marker1.Type, episode.Id, null, null, episode.Marker1.Start, episode.Marker1.End, episode.Marker1.Index, episode.Marker1.Final, this.testDb);
+        // TODO: Credits
+        await TestHelpers.validateMarker(response.markers[1], null, episode.Id, null, null, episode.Marker2.Start, episode.Marker2.End, episode.Marker2.Index, null, this.testDb);
+        // TODO: Credits
+        await TestHelpers.validateMarker(response.markers[2], null, episode.Id, null, null, episode.Marker3.Start, episode.Marker3.End, episode.Marker3.Index, null, this.testDb);
         TestHelpers.verify(response.episodeData && response.episodeData[episode.Id], `Expected dry run to have episode data for ${episode.Id}, didn't find any.`);
         TestHelpers.verify(Object.keys(response.episodeData).length == 1, `Expected data for a single episode, found ${Object.keys(response.episodeData).length}.`);
         length = response.deletedMarkers ? response.deletedMarkers.length : undefined;
@@ -53,13 +56,14 @@ class BulkDeleteTest extends TestBase {
         const season = TestBase.DefaultMetadata.Show3.Season1;
         const response = await this.#bulkDelete(season.Id, true);
         let length = (response && response.markers) ? response.markers.length : undefined;
-        TestHelpers.verify(length == 3, `Expected 3 markers in dry run, found ${length}`);
+        TestHelpers.verify(length == 4, `Expected 3 markers in dry run, found ${length}`);
         length = response.deletedMarkers ? response.deletedMarkers.length : undefined;
         TestHelpers.verify(length === 0, `Dry run should never have deleted markers, found ${length}`);
         const sorted = response.markers.sort((a, b) => a.id - b.id);
         let i = 0;
-        for (const testMarker of [season.Episode1.Marker1, season.Episode2.Marker1, season.Episode2.Marker2]) {
-            await TestHelpers.validateMarker(sorted[i++], null, season.Id, null, testMarker.Start, testMarker.End, testMarker.Index, this.testDb);
+        for (const testMarker of [season.Episode1.Marker1, season.Episode2.Marker1, season.Episode2.Marker2, season.Episode2.Marker3]) {
+            // TODO: Credits
+            await TestHelpers.validateMarker(sorted[i++], null, null, season.Id, null, testMarker.Start, testMarker.End, testMarker.Index, null, this.testDb);
         }
 
 
@@ -72,13 +76,14 @@ class BulkDeleteTest extends TestBase {
         const show = TestBase.DefaultMetadata.Show3;
         const response = await this.#bulkDelete(show.Id, true);
         let length = (response && response.markers) ? response.markers.length : undefined;
-        TestHelpers.verify(length == 4, `Expected 4 markers in dry run, found ${length}`);
+        TestHelpers.verify(length == 5, `Expected 5 markers in dry run, found ${length}`);
         length = response.deletedMarkers ? response.deletedMarkers.length : undefined;
         TestHelpers.verify(length === 0, `Dry run should never have deleted markers, found ${length}`);
         const sorted = response.markers.sort((a, b) => a.id - b.id);
         let i = 0;
-        for (const testMarker of [show.Season1.Episode1.Marker1, show.Season1.Episode2.Marker1, show.Season1.Episode2.Marker2, show.Season2.Episode1.Marker1]) {
-            await TestHelpers.validateMarker(sorted[i++], null, null, show.Id, testMarker.Start, testMarker.End, testMarker.Index, this.testDb);
+        for (const testMarker of [show.Season1.Episode1.Marker1, show.Season1.Episode2.Marker1, show.Season1.Episode2.Marker2, show.Season1.Episode2.Marker3, show.Season2.Episode1.Marker1]) {
+            // TODO: Credits
+            await TestHelpers.validateMarker(sorted[i++], null, null, null, show.Id, testMarker.Start, testMarker.End, testMarker.Index, null, this.testDb);
         }
 
         i = 0;
@@ -103,7 +108,7 @@ class BulkDeleteTest extends TestBase {
         TestHelpers.verify(length === 1, `Expected 1 deleted marker, found ${length}`);
 
         const fakeMarker = { id : episode.Marker1.Id };
-        await TestHelpers.validateMarker(fakeMarker, null, null, null, null, null, null, this.testDb, true /*isDeleted*/);
+        await TestHelpers.validateMarker(fakeMarker, null, null, null, null, null, null, null, null, this.testDb, true /*isDeleted*/);
 
         // Multiple markers
         episode = TestBase.DefaultMetadata.Show3.Season1.Episode2;
@@ -111,12 +116,12 @@ class BulkDeleteTest extends TestBase {
         length = (response && response.markers) ? response.markers.length : undefined;
         TestHelpers.verify(length === 0, `Expected bulk delete without ignore list to return empty marker array, found ${length}`);
         length = response.deletedMarkers ? response.deletedMarkers.length : undefined;
-        TestHelpers.verify(length === 2, `Expected 2 deleted markers, found ${length}`);
+        TestHelpers.verify(length === 3, `Expected 3 deleted markers, found ${length}`);
 
         const fakeMarker1 = { id : episode.Marker1.Id };
-        await TestHelpers.validateMarker(fakeMarker1, null, null, null, null, null, null, this.testDb, true /*isDeleted*/);
+        await TestHelpers.validateMarker(fakeMarker1, null, null, null, null, null, null, null, null, this.testDb, true /*isDeleted*/);
         const fakeMarker2 = { id : episode.Marker2.Id };
-        await TestHelpers.validateMarker(fakeMarker2, null, null, null, null, null, null, this.testDb, true /*isDeleted*/);
+        await TestHelpers.validateMarker(fakeMarker2, null, null, null, null, null, null, null, null, this.testDb, true /*isDeleted*/);
     }
 
     async bulkDeleteSeasonTest() {
@@ -125,10 +130,10 @@ class BulkDeleteTest extends TestBase {
         let length = (response && response.markers) ? response.markers.length : undefined;
         TestHelpers.verify(length === 0, `Expected bulk delete without ignore list to return empty marker array, found ${length}`);
         length = response.deletedMarkers ? response.deletedMarkers.length : undefined;
-        TestHelpers.verify(length === 3, `Expected 3 deleted markers, found ${length}`);
+        TestHelpers.verify(length === 4, `Expected 4 deleted markers, found ${length}`);
 
         for (const testMarker of [season.Episode1.Marker1, season.Episode2.Marker1, season.Episode2.Marker2]) {
-            await TestHelpers.validateMarker({ id : testMarker.Id }, null, null, null, null, null, null, this.testDb, true /*isDeleted*/);
+            await TestHelpers.validateMarker({ id : testMarker.Id }, null, null, null, null, null, null, null, null, this.testDb, true /*isDeleted*/);
         }
     }
 
@@ -138,10 +143,10 @@ class BulkDeleteTest extends TestBase {
         let length = (response && response.markers) ? response.markers.length : undefined;
         TestHelpers.verify(length === 0, `Expected bulk delete without ignore list to return empty marker array, found ${length}`);
         length = response.deletedMarkers ? response.deletedMarkers.length : undefined;
-        TestHelpers.verify(length === 4, `Expected 4 deleted markers, found ${length}`);
+        TestHelpers.verify(length === 5, `Expected 4 deleted markers, found ${length}`);
 
         for (const testMarker of [show.Season1.Episode1.Marker1, show.Season1.Episode2.Marker1, show.Season1.Episode2.Marker2, show.Season2.Episode1.Marker1]) {
-            await TestHelpers.validateMarker({ id : testMarker.Id }, null, null, null, null, null, null, this.testDb, true /*isDeleted*/);
+            await TestHelpers.validateMarker({ id : testMarker.Id }, null, null, null, null, null, null, null, null, this.testDb, true /*isDeleted*/);
         }
     }
 
@@ -156,7 +161,7 @@ class BulkDeleteTest extends TestBase {
 
         // Make sure it's not deleted
         const fakeMarker = { id : episode.Marker1.Id };
-        await TestHelpers.validateMarker(fakeMarker, null, null, null, null, null, null, this.testDb, false /*isDeleted*/);
+        await TestHelpers.validateMarker(fakeMarker, null, null, null, null, null, null, null, null, this.testDb, false /*isDeleted*/);
 
         // Multiple markers
         episode = TestBase.DefaultMetadata.Show3.Season1.Episode2;
@@ -164,12 +169,14 @@ class BulkDeleteTest extends TestBase {
         length = (response && response.markers) ? response.markers.length : undefined;
         TestHelpers.verify(length === 1, `Expected bulk delete ignore list to return marker array of size 1, found ${length}`);
         length = response.deletedMarkers ? response.deletedMarkers.length : undefined;
-        TestHelpers.verify(length === 1, `Expected 1 deleted marker, found ${length}`);
+        TestHelpers.verify(length === 2, `Expected 2 deleted markers, found ${length}`);
 
         const fakeMarker1 = { id : episode.Marker1.Id };
-        await TestHelpers.validateMarker(fakeMarker1, null, null, null, null, null, null, this.testDb, true /*isDeleted*/);
+        await TestHelpers.validateMarker(fakeMarker1, null, null, null, null, null, null, null, null, this.testDb, true /*isDeleted*/);
         const fakeMarker2 = { id : episode.Marker2.Id, index : 0 };
-        await TestHelpers.validateMarker(fakeMarker2, null, null, null, null, null, 0, this.testDb, false /*isDeleted*/);
+        await TestHelpers.validateMarker(fakeMarker2, null, null, null, null, null, null, null, 0, this.testDb, false /*isDeleted*/);
+        const fakeMarker3 = { id : episode.Marker3.Id, index : 0 };
+        await TestHelpers.validateMarker(fakeMarker3, null, null, null, null, null, null, null, 0, this.testDb, true /*isDeleted*/);
     }
 
     async bulkDeleteSeasonWithIgnoreTest() {
@@ -178,12 +185,12 @@ class BulkDeleteTest extends TestBase {
         let length = (response && response.markers) ? response.markers.length : undefined;
         TestHelpers.verify(length === 1, `Expected bulk delete ignore list of 1 to return marker array of length 1, found ${length}`);
         length = response.deletedMarkers ? response.deletedMarkers.length : undefined;
-        TestHelpers.verify(length === 2, `Expected 2 deleted markers, found ${length}`);
+        TestHelpers.verify(length === 3, `Expected 3 deleted markers, found ${length}`);
 
-        for (const testMarker of [season.Episode1.Marker1, season.Episode2.Marker1]) {
-            await TestHelpers.validateMarker({ id : testMarker.Id }, null, null, null, null, null, null, this.testDb, true /*isDeleted*/);
+        for (const testMarker of [season.Episode1.Marker1, season.Episode2.Marker1, season.Episode2.Marker3]) {
+            await TestHelpers.validateMarker({ id : testMarker.Id }, null, null, null, null, null, null, null, null, this.testDb, true /*isDeleted*/);
         }
-        await TestHelpers.validateMarker({ id : season.Episode2.Marker2.Id }, null, null, null, null, null, null, this.testDb, false /*isDeleted*/);
+        await TestHelpers.validateMarker({ id : season.Episode2.Marker2.Id }, null, null, null, null, null, null, null, null, this.testDb, false /*isDeleted*/);
     }
 
     async bulkDeleteShowWithIgnoreTest() {
@@ -192,14 +199,14 @@ class BulkDeleteTest extends TestBase {
         let length = (response && response.markers) ? response.markers.length : undefined;
         TestHelpers.verify(length === 2, `Expected bulk delete ignore list of 2 to return marker array of length 2, found ${length}`);
         length = response.deletedMarkers ? response.deletedMarkers.length : undefined;
-        TestHelpers.verify(length === 2, `Expected 2 deleted markers, found ${length}`);
+        TestHelpers.verify(length === 3, `Expected 3 deleted markers, found ${length}`);
 
-        for (const testMarker of [show.Season1.Episode2.Marker2, show.Season2.Episode1.Marker1]) {
-            await TestHelpers.validateMarker({ id : testMarker.Id }, null, null, null, null, null, null, this.testDb, true /*isDeleted*/);
+        for (const testMarker of [show.Season1.Episode2.Marker2, show.Season2.Episode1.Marker1, show.Season1.Episode2.Marker3]) {
+            await TestHelpers.validateMarker({ id : testMarker.Id }, null, null, null, null, null, null, null, null, this.testDb, true /*isDeleted*/);
         }
 
         for (const testMarker of [show.Season1.Episode1.Marker1, show.Season1.Episode2.Marker1]) {
-            await TestHelpers.validateMarker({ id : testMarker.Id }, null, null, null, null, null, null, this.testDb, false /*isDeleted*/);
+            await TestHelpers.validateMarker({ id : testMarker.Id }, null, null, null, null, null, null, null, null, this.testDb, false /*isDeleted*/);
         }
     }
 

--- a/Test/TestClasses/BulkDeleteTest.js
+++ b/Test/TestClasses/BulkDeleteTest.js
@@ -174,9 +174,9 @@ class BulkDeleteTest extends TestBase {
         const fakeMarker1 = { id : episode.Marker1.Id };
         await TestHelpers.validateMarker(fakeMarker1, null, null, null, null, null, null, null, null, this.testDb, true /*isDeleted*/);
         const fakeMarker2 = { id : episode.Marker2.Id, index : 0 };
-        await TestHelpers.validateMarker(fakeMarker2, null, null, null, null, null, null, null, 0, this.testDb, false /*isDeleted*/);
+        await TestHelpers.validateMarker(fakeMarker2, null, null, null, null, null, null, null, null, this.testDb, false /*isDeleted*/);
         const fakeMarker3 = { id : episode.Marker3.Id, index : 0 };
-        await TestHelpers.validateMarker(fakeMarker3, null, null, null, null, null, null, null, 0, this.testDb, true /*isDeleted*/);
+        await TestHelpers.validateMarker(fakeMarker3, null, null, null, null, null, null, null, null, this.testDb, true /*isDeleted*/);
     }
 
     async bulkDeleteSeasonWithIgnoreTest() {

--- a/Test/TestClasses/MultipleMarkersTest.js
+++ b/Test/TestClasses/MultipleMarkersTest.js
@@ -28,12 +28,14 @@ class MultipleMarkers extends TestBase {
 
         await TestHelpers.validateMarker(
             marker,
+            'intro',
             eid,
             show.Season1.Id,
             show.Id,
             50000 /*start*/,
             60000 /*end*/,
             1 /*index*/,
+            false /*final*/,
             this.testDb
         );
 
@@ -65,12 +67,14 @@ class MultipleMarkers extends TestBase {
 
         await TestHelpers.validateMarker(
             marker,
+            'intro',
             eid,
             show.Season1.Id,
             show.Id,
             0 /*start*/,
             10000 /*end*/,
             0 /*index*/,
+            false /*final*/,
             this.testDb
         );
 
@@ -120,12 +124,12 @@ class MultipleMarkers extends TestBase {
      * Ensure that marker indexes are resolved correctly after one is deleted. */
     async testReindexAfterDelete() {
         const episode = TestBase.DefaultMetadata.Show3.Season1.Episode2;
-        await TestHelpers.validateMarker({ id : episode.Marker2.Id, index : episode.Marker2.Index }, null, null, null, null, null, 1, this.testDb);
+        await TestHelpers.validateMarker({ id : episode.Marker2.Id, index : episode.Marker2.Index }, null, null, null, null, null, null, 1, null, this.testDb);
         let response = await this.send('delete', { id : episode.Marker1.Id });
         TestHelpers.verify(response && response.id == episode.Marker1.Id, `Expected marker delete to return the marker we deleted.`);
 
         // Verify the index of the second marker is now 0
-        await TestHelpers.validateMarker({ id : episode.Marker2.Id, index : 0 }, null, null, null, null, null, 0, this.testDb);
+        await TestHelpers.validateMarker({ id : episode.Marker2.Id, index : 0 }, null, null, null, null, null, null, 0, null, this.testDb);
     }
 
     /**

--- a/Test/TestClasses/ShiftTest.js
+++ b/Test/TestClasses/ShiftTest.js
@@ -162,7 +162,7 @@ class ShiftTest extends TestBase {
         const shift = 345000;
         const result = await this.#verifyJoinedShift(episode.Id, shift, 1, [episode.Marker2.Id, episode.Marker3.Id]);
         const newMarker = result.allMarkers[0];
-        await TestHelpers.validateMarker(newMarker, episode.Marker1.Type, episode.Id, null, null, episode.Marker1.Start + shift, episode.Marker1.End + shift, 2, episode.Marker1.Final, this.testDb);
+        await TestHelpers.validateMarker(newMarker, episode.Marker1.Type, episode.Id, null, null, episode.Marker1.Start + shift, episode.Marker1.End + shift, 1, episode.Marker1.Final, this.testDb);
 
         // Fake marker data to verify that the second marker wasn't changed
         const marker2 = episode.Marker2;

--- a/Test/TestClasses/ShiftTest.js
+++ b/Test/TestClasses/ShiftTest.js
@@ -36,7 +36,7 @@ class ShiftTest extends TestBase {
         const shift = 3000;
         const result = await this.#verifyJoinedShift(episode.Id, shift, 1);
         const newMarker = result.allMarkers[0];
-        return TestHelpers.validateMarker(newMarker, episode.Id, null, null, episode.Marker1.Start + shift, episode.Marker1.End + shift, 0, this.testDb);
+        return TestHelpers.validateMarker(newMarker, episode.Marker1.Type, episode.Id, null, null, episode.Marker1.Start + shift, episode.Marker1.End + shift, 0, episode.Marker1.Final, this.testDb);
     }
 
     /**
@@ -46,7 +46,7 @@ class ShiftTest extends TestBase {
         const shift = -3000;
         const result = await this.#verifyJoinedShift(episode.Id, shift, 1);
         const newMarker = result.allMarkers[0];
-        return TestHelpers.validateMarker(newMarker, episode.Id, null, null, episode.Marker1.Start + shift, episode.Marker1.End + shift, 0, this.testDb);
+        return TestHelpers.validateMarker(newMarker, episode.Marker1.Type, episode.Id, null, null, episode.Marker1.Start + shift, episode.Marker1.End + shift, 0, episode.Marker1.Final, this.testDb);
     }
 
     /**
@@ -58,7 +58,7 @@ class ShiftTest extends TestBase {
         const result = await this.#verifyAttemptedShift(episode.Id, 1, 1, true, false);
         const checkedMarker = result.allMarkers[0];
 
-        return TestHelpers.validateMarker(checkedMarker, episode.Id, null, null, expectedMarker.Start, expectedMarker.End, expectedMarker.Index, this.testDatabase);
+        return TestHelpers.validateMarker(checkedMarker, expectedMarker.Type, episode.Id, null, null, expectedMarker.Start, expectedMarker.End, expectedMarker.Index, expectedMarker.Final, this.testDatabase);
     }
 
     /**
@@ -69,7 +69,7 @@ class ShiftTest extends TestBase {
         TestHelpers.verify(episode.Marker1.Start + shift < 0, `episode.Marker1.Start + shift < 0: Can't test start cutoff if we don't shift this enough!`);
         const result = await this.#verifyJoinedShift(episode.Id, shift, 1);
         const newMarker = result.allMarkers[0];
-        return TestHelpers.validateMarker(newMarker, episode.Id, null, null, 0, episode.Marker1.End + shift, 0, this.testDb);
+        return TestHelpers.validateMarker(newMarker, episode.Marker1.Type, episode.Id, null, null, 0, episode.Marker1.End + shift, 0, episode.Marker1.Final, this.testDb);
     }
 
     /**
@@ -80,7 +80,7 @@ class ShiftTest extends TestBase {
         TestHelpers.verify(episode.Marker1.End + shift > 600000, `episode.Marker1.End + shift > 600000: Can't test end cutoff if we don't shift this enough!`);
         const result = await this.#verifyJoinedShift(episode.Id, shift, 1);
         const newMarker = result.allMarkers[0];
-        return TestHelpers.validateMarker(newMarker, episode.Id, null, null, episode.Marker1.Start + shift, 600000, 0, this.testDb);
+        return TestHelpers.validateMarker(newMarker, episode.Marker1.Type, episode.Id, null, null, episode.Marker1.Start + shift, 600000, 0, episode.Marker1.Final, this.testDb);
     }
 
     /**
@@ -127,7 +127,7 @@ class ShiftTest extends TestBase {
         const result = await this.#verifyJoinedShift(season.Id, shift, 1);
         const newMarker = result.allMarkers[0];
         const oldMarker = season.Episode2.Marker1;
-        return TestHelpers.validateMarker(newMarker, null, season.Id, null, oldMarker.Start + shift, oldMarker.End + shift, 0, this.testDb);
+        return TestHelpers.validateMarker(newMarker, oldMarker.Type, null, season.Id, null, oldMarker.Start + shift, oldMarker.End + shift, 0, oldMarker.Final, this.testDb);
     }
 
     /**
@@ -138,22 +138,21 @@ class ShiftTest extends TestBase {
         const result = await this.#verifyJoinedShift(show.Id, shift, 1);
         const newMarker = result.allMarkers[0];
         const oldMarker = show.Season1.Episode2.Marker1;
-        return TestHelpers.validateMarker(newMarker, null, null, show.Id, oldMarker.Start + shift, oldMarker.End + shift, 0, this.testDb);
-
+        return TestHelpers.validateMarker(newMarker, oldMarker.Type, null, null, show.Id, oldMarker.Start + shift, oldMarker.End + shift, 0, oldMarker.Final, this.testDb);
     }
 
     /**
      * Ensure we don't apply anything when only checking the shift and the episode has multiple markers. */
     async shiftSingleEpisodeWithMultipleMarkersDontApplyTest() {
         const episode = TestBase.DefaultMetadata.Show3.Season1.Episode2;
-        return this.#verifyAttemptedShift(episode.Id, 2, 1, true);
+        return this.#verifyAttemptedShift(episode.Id, 3, 1, true);
     }
 
     /**
      * Ensure we don't apply anything when an episode has multiple markers and we aren't forcing the operation. */
     async shiftSingleEpisodeWithMultipleMarkersTryApplyTest() {
         const episode = TestBase.DefaultMetadata.Show3.Season1.Episode2;
-        return this.#verifyAttemptedShift(episode.Id, 2, 1);
+        return this.#verifyAttemptedShift(episode.Id, 3, 1);
     }
 
     /**
@@ -161,15 +160,15 @@ class ShiftTest extends TestBase {
     async shiftSingleEpisodeWithMultipleMarkersTryApplyWithIgnoreTest() {
         const episode = TestBase.DefaultMetadata.Show3.Season1.Episode2;
         const shift = 345000;
-        const result = await this.#verifyJoinedShift(episode.Id, shift, 1, [episode.Marker2.Id]);
+        const result = await this.#verifyJoinedShift(episode.Id, shift, 1, [episode.Marker2.Id, episode.Marker3.Id]);
         const newMarker = result.allMarkers[0];
-        await TestHelpers.validateMarker(newMarker, episode.Id, null, null, episode.Marker1.Start + shift, episode.Marker1.End + shift, 1, this.testDb);
+        await TestHelpers.validateMarker(newMarker, episode.Marker1.Type, episode.Id, null, null, episode.Marker1.Start + shift, episode.Marker1.End + shift, 2, episode.Marker1.Final, this.testDb);
 
         // Fake marker data to verify that the second marker wasn't changed
         const marker2 = episode.Marker2;
         TestHelpers.verify(marker2.Index == 1, `This test assumes marker2 has an index of 1, test data has changed!`);
         const fakeMarkerData = { id : marker2.Id, start : marker2.Start, end : marker2.End, index : 0 };
-        return TestHelpers.validateMarker(fakeMarkerData, null, null, null, marker2.Start, marker2.End, 0, this.testDb);
+        return TestHelpers.validateMarker(fakeMarkerData, null, null, null, null, marker2.Start, marker2.End, 0, null, this.testDb);
     }
 
     /**
@@ -177,14 +176,14 @@ class ShiftTest extends TestBase {
     async shiftSingleEpisodeWithMultipleMarkersForceApplyTest() {
         const episode = TestBase.DefaultMetadata.Show3.Season1.Episode2;
         const shift = 3000;
-        const result = await this.#verifyJoinedShift(episode.Id, shift, 2, [], true, 1);
+        const result = await this.#verifyJoinedShift(episode.Id, shift, 3, [], true, 1);
         /** @type {MarkerData[]} */
         const newMarkers = result.allMarkers;
 
         // Order not guaranteed.
         const sorted = newMarkers.sort((a, b) => a.id - b.id);
-        await TestHelpers.validateMarker(sorted[0], episode.Id, null, null, episode.Marker1.Start + shift, episode.Marker1.End + shift, 0, this.testDb);
-        await TestHelpers.validateMarker(sorted[1], episode.Id, null, null, episode.Marker2.Start + shift, episode.Marker2.End + shift, 1, this.testDb);
+        await TestHelpers.validateMarker(sorted[0], episode.Marker1.Type, episode.Id, null, null, episode.Marker1.Start + shift, episode.Marker1.End + shift, 0, episode.Marker1.Final, this.testDb);
+        await TestHelpers.validateMarker(sorted[1], episode.Marker2.Type, episode.Id, null, null, episode.Marker2.Start + shift, episode.Marker2.End + shift, 1, episode.Marker2.Final, this.testDb);
     }
 
     /**
@@ -193,26 +192,26 @@ class ShiftTest extends TestBase {
     async shiftSeasonWithIgnoreTest() {
         const season = TestBase.DefaultMetadata.Show3.Season1;
         const shift = 3000;
-        const result = await this.#verifyJoinedShift(season.Id, shift, 2, [season.Episode2.Marker2.Id]);
+        const result = await this.#verifyJoinedShift(season.Id, shift, 2, [season.Episode2.Marker2.Id, season.Episode2.Marker3.Id]);
         /** @type {MarkerData[]} */
         const newMarkers = result.allMarkers;
 
         // Order not guaranteed.
         const sorted = newMarkers.sort((a, b) => a.id - b.id);
-        await TestHelpers.validateMarker(sorted[0], null, season.Id, null, season.Episode1.Marker1.Start + shift, season.Episode1.Marker1.End + shift, 0, this.testDb);
-        await TestHelpers.validateMarker(sorted[1], null, season.Id, null, season.Episode2.Marker1.Start + shift, season.Episode2.Marker1.End + shift, 0, this.testDb);
+        await TestHelpers.validateMarker(sorted[0], season.Episode1.Marker1.Type, null, season.Id, null, season.Episode1.Marker1.Start + shift, season.Episode1.Marker1.End + shift, 0, season.Episode1.Marker1.Final, this.testDb);
+        await TestHelpers.validateMarker(sorted[1], season.Episode2.Marker1.Type, null, season.Id, null, season.Episode2.Marker1.Start + shift, season.Episode2.Marker1.End + shift, 0, season.Episode2.Marker1.Final, this.testDb);
 
         // Fake marker data to verify that the ignored marker wasn't changed
         const marker2 = season.Episode2.Marker2;
         const fakeMarkerData = { id : marker2.Id, start : marker2.Start, end : marker2.End, index : marker2.Index };
-        return TestHelpers.validateMarker(fakeMarkerData, null, null, null, marker2.Start, marker2.End, marker2.Index);
+        return TestHelpers.validateMarker(fakeMarkerData, null, null, null, null, marker2.Start, marker2.End, marker2.Index, null);
     }
 
     /**
      * Ensure we don't apply if any episodes in the season have multiple markers when not force applying. */
     async tryShiftSeasonWithoutIgnoreTest() {
         const season = TestBase.DefaultMetadata.Show3.Season1;
-        return this.#verifyAttemptedShift(season.Id, 3, 2, true);
+        return this.#verifyAttemptedShift(season.Id, 4, 2, true);
     }
 
     /**
@@ -221,20 +220,20 @@ class ShiftTest extends TestBase {
     async shiftShowWithIgnoreTest() {
         const show = TestBase.DefaultMetadata.Show3;
         const shift = 3000;
-        const result = await this.#verifyJoinedShift(show.Id, shift, 3, [show.Season1.Episode2.Marker1.Id]);
+        const result = await this.#verifyJoinedShift(show.Id, shift, 3, [show.Season1.Episode2.Marker1.Id, show.Season1.Episode2.Marker3.Id]);
         /** @type {MarkerData[]} */
         const newMarkers = result.allMarkers;
 
         // Order not guaranteed.
         const sorted = newMarkers.sort((a, b) => a.id - b.id);
-        await TestHelpers.validateMarker(sorted[0], null, null, show.Id, show.Season1.Episode1.Marker1.Start + shift, show.Season1.Episode1.Marker1.End + shift, 0, this.testDb);
-        await TestHelpers.validateMarker(sorted[1], null, null, show.Id, show.Season1.Episode2.Marker2.Start + shift, show.Season1.Episode2.Marker2.End + shift, 1, this.testDb);
-        await TestHelpers.validateMarker(sorted[2], null, null, show.Id, show.Season2.Episode1.Marker1.Start + shift, show.Season2.Episode1.Marker1.End + shift, 0, this.testDb);
+        await TestHelpers.validateMarker(sorted[0], null, null, null, show.Id, show.Season1.Episode1.Marker1.Start + shift, show.Season1.Episode1.Marker1.End + shift, 0, null, this.testDb);
+        await TestHelpers.validateMarker(sorted[1], null, null, null, show.Id, show.Season1.Episode2.Marker2.Start + shift, show.Season1.Episode2.Marker2.End + shift, 1, null, this.testDb);
+        await TestHelpers.validateMarker(sorted[2], null, null, null, show.Id, show.Season2.Episode1.Marker1.Start + shift, show.Season2.Episode1.Marker1.End + shift, 0, null, this.testDb);
 
         // Fake marker data to verify that the ignored marker wasn't changed
         const marker1 = show.Season1.Episode2.Marker1;
         const fakeMarkerData = { id : marker1.Id, start : marker1.Start, end : marker1.End, index : marker1.Index };
-        return TestHelpers.validateMarker(fakeMarkerData, null, null, null, marker1.Start, marker1.End, marker1.Index);
+        return TestHelpers.validateMarker(fakeMarkerData, null, null, null, null, marker1.Start, marker1.End, marker1.Index, null);
     }
 
     /**
@@ -247,7 +246,7 @@ class ShiftTest extends TestBase {
         const result = await this.#verifySplitShift(season.Id, startShift, endShift, 1);
         const newMarker = result.allMarkers[0];
         const oldMarker = season.Episode2.Marker1;
-        return TestHelpers.validateMarker(newMarker, null, season.Id, null, oldMarker.Start + startShift, oldMarker.End + endShift, 0, this.testDb);
+        return TestHelpers.validateMarker(newMarker, null, null, season.Id, null, oldMarker.Start + startShift, oldMarker.End + endShift, 0, null, this.testDb);
     }
 
     /**

--- a/Test/TestHelpers.js
+++ b/Test/TestHelpers.js
@@ -10,24 +10,28 @@ class TestHelpers {
      * Validate an added/edited/deleted marker to ensure it matches both what is expected,
      * and what is actually in the database. If an expected value is null, then it is not validated.
      * @param {SerializedMarkerData} markerData The marker to validate. May also be a Failure response ({ Error : string })
+     * @param {string?} expectedType
      * @param {number?} expectedEpisodeId
      * @param {number?} expectedSeasonId
      * @param {number?} expectedShowId
      * @param {number?} expectedStart
      * @param {number?} expectedEnd
      * @param {number?} expectedIndex
+     * @param {boolean?} expectedFinal
      * @param {DatabaseWrapper?} database The test database
      * @param {boolean} isDeleted Whether markerData is a deleted marker (i.e. we should verify it doesn't exist in the database)
      * @throws if the marker is not valid.
      */
     static async validateMarker(
             markerData,
+            expectedType=null,
             expectedEpisodeId=null,
             expectedSeasonId=null,
             expectedShowId=null,
             expectedStart=null,
             expectedEnd=null,
             expectedIndex=null,
+            expectedFinal=null,
             database=null,
             isDeleted=false) {
         if (!markerData) {
@@ -48,12 +52,15 @@ class TestHelpers {
             }
         }
 
+        checkField(markerData.markerType, expectedType, 'Marker type');
         checkField(markerData.episodeId, expectedEpisodeId, 'Episode id');
         checkField(markerData.seasonId, expectedSeasonId, 'Season id');
         checkField(markerData.showId, expectedShowId, 'Show id');
         checkField(markerData.start, expectedStart, 'Marker start');
         checkField(markerData.end, expectedEnd, 'Marker end');
         checkField(markerData.index, expectedIndex, 'Marker index');
+        checkField(markerData.isFinal, expectedFinal, 'Final credits');
+
 
         // Verified returned fields, make sure it's in the db as well
         TestHelpers.verify(allIssues.length == 0, allIssues);
@@ -75,6 +82,8 @@ class TestHelpers {
         checkField(row.time_offset, expectedStart, 'DB marker start');
         checkField(row.end_time_offset, expectedEnd, 'DB marker end');
         checkField(row.index, expectedIndex, 'DB marker index');
+        checkField(row.text, expectedType, 'DB marker type');
+        checkField(row.extra_data.indexOf('final=1') !== -1, expectedFinal, 'Final credits');
         TestHelpers.verify(allIssues.length == 0, allIssues);
     }
 

--- a/Test/TestHelpers.js
+++ b/Test/TestHelpers.js
@@ -21,6 +21,7 @@ class TestHelpers {
      * @param {DatabaseWrapper?} database The test database
      * @param {boolean} isDeleted Whether markerData is a deleted marker (i.e. we should verify it doesn't exist in the database)
      * @throws if the marker is not valid.
+     * TODO: indexRemove: replace index with order for all callers.
      */
     static async validateMarker(
             markerData,
@@ -58,7 +59,7 @@ class TestHelpers {
         checkField(markerData.showId, expectedShowId, 'Show id');
         checkField(markerData.start, expectedStart, 'Marker start');
         checkField(markerData.end, expectedEnd, 'Marker end');
-        checkField(markerData.index, expectedIndex, 'Marker index');
+        checkField(markerData.index, expectedIndex, 'Marker index'); // TODO: indexRemove: order
         checkField(markerData.isFinal, expectedFinal, 'Final credits');
 
 
@@ -81,7 +82,7 @@ class TestHelpers {
         checkField(row.metadata_item_id, expectedEpisodeId, 'DB episode id');
         checkField(row.time_offset, expectedStart, 'DB marker start');
         checkField(row.end_time_offset, expectedEnd, 'DB marker end');
-        checkField(row.index, expectedIndex, 'DB marker index');
+        checkField(row.index, expectedIndex, 'DB marker index'); // TODO: indexRemove: order
         checkField(row.text, expectedType, 'DB marker type');
         checkField(row.extra_data.indexOf('final=1') !== -1, expectedFinal, 'Final credits');
         TestHelpers.verify(allIssues.length == 0, allIssues);

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         </label>
     </div>
     <div id="intro">
-        <h1 id="siteTitle">Intro Editor for Plex <img id="settings" class="hidden" src="/i/c1c1c1/settings.svg" width="20px" height="20px" alt="Settings" title="Settings" theme="standard"></h1>
+        <h1 id="siteTitle">Intro Editor <img id="settings" class="hidden" src="/i/c1c1c1/settings.svg" width="20px" height="20px" alt="Settings" title="Settings" theme="standard"></h1>
     </div>
     <form>
         <div id="libraryList"><label for="libraries" class="hidden">Library selection</label><select id="libraries"></select></div>


### PR DESCRIPTION
# feature/credits, V1

Add initial support for 'credits' markers in addition to 'intro'. In this PR, only TV episodes are supported, but movie integration is planned for the final release, likely 2.0.

Summary of major changes (some of which aren't specific to credits support):

* Backup database:
    * Credits specific changes: add `marker_type` and `final` columns to indicate the type of marker (intro/credits), and if it's a credits marker, whether it indicates the `final` marker that will invoke the PostPlay screen in Plex.
    * General changes: Sometime in late 2022 Plex changed the `taggings` table to use epoch timestamps instead of datetime strings. Follow suit by
        * Converting the existing `modified_at`/`created_at`/`recorded_at` fields from `datetime` to `integer` epoch timestamps.
        * Adding a `user_created` column, which servers the same purpose that appending `*` to the `modified_at` date used to.
        * Update Plex's `taggings` table to adjust hacked `thumb_url` timestamps to epoch timestamps, and since we can't add a column and adding `*` to an integer doesn't make sense, use a negative value to indicate user created markers.
* Credits showed that a marker's `index` does not correlate to it's "position" in the episode (commercial skips probably could have told me that). Use the `time_offset` (`start`) instead, and ensure things are sorted client-side. Update various `index`-based calculations to instead use the already-sorted marker array that various features hold on to.
    * TODO: get rid of the concept of re-indexing entirely, outside of adjusting for deleted markers.
* Server commands: add `markerType`/`final` parameters to relevant actions (`add`, `edit`, and `bulk_add`).
* Replace the marker table's `Index` column with the marker type. When adding/editing, make it a dropdown to select from the various marker types. If the Ctrl+Shift+E command is invoked (move the end timestamp to the end of the episode), automatically switch the type to `Credits`.
* [Unrelated to Credits]: Fix error hints when bulk adding - ensure errors/warnings are shown when the new marker starts beyond the episode's duration, and when it completely encapsulates an existing marker.

**Note**: Tests _do not_ pass. They've been re-worked for some new features, but not everything.